### PR TITLE
Ensure configuration file sanity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ FFXIV_TexTools_CLI/obj
 FFXIV_Modding_Tool/bin
 FFXIV_Modding_Tool/obj
 .github
+testing
 
 
 

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -64,17 +64,37 @@ Available arguments:
                             {
                                 MainClass._gameDirectory = new DirectoryInfo(Path.Combine(nextArg, "game"));
                                 MainClass._indexDirectory = new DirectoryInfo(Path.Combine(nextArg, "game", "sqpack", "ffxiv"));
+                                if (!main.ValidGameDirectory())
+                                {
+                                    main.PrintMessage($"{nextArg} is not a valid game directory. Falling back to config file", 3);
+                                    MainClass._gameDirectory = null;
+                                    MainClass._indexDirectory = null;
+                                }
                             }
                             continue;
                         case "c":
                         case "configdirectory":
                             if (!nextArg.StartsWith("-"))
+                            {
                                 MainClass._configDirectory = new DirectoryInfo(nextArg);
+                                if (!main.ValidGameConfigDirectory())
+                                {
+                                    main.PrintMessage($"{nextArg} is not a valid game config directory. Falling back to config file", 3);
+                                    MainClass._configDirectory = null;
+                                }
+                            }
                             continue;
                         case "b":
                         case "backupdirectory":
                             if (!nextArg.StartsWith("-"))
+                            {
                                 MainClass._backupDirectory = new DirectoryInfo(nextArg);
+                                if (!main.ValidBackupDirectory())
+                                {
+                                    main.PrintMessage($"{nextArg} does not exist. Falling back to config file", 3);
+                                    MainClass._backupDirectory = null;
+                                }
+                            }
                             continue;
                         case "t":
                         case "ttmp":

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -99,61 +99,64 @@ namespace FFXIV_Modding_Tool.Commandline
             string secondAction = "";
             if (args.Count() > 1)
                 secondAction = args[1];
-            switch (args[0])
+            if (string.IsNullOrEmpty(requestedAction))
             {
-                case "mpi":
-                    requestedAction = "mpi";
-                    break;
-                case "mpinfo":
-                    requestedAction = "mpinfo";
-                    break;
-                case "modpack":
-                    if (secondAction == "import")
-                        goto case "mpi";
-                    if (secondAction == "info")
-                        goto case "mpinfo";
-                    break;
-                case "mr":
-                    requestedAction = "mr";
-                    break;
-                case "me":
-                    requestedAction = "me";
-                    break;
-                case "md":
-                    requestedAction = "md";
-                    break;
-                case "mods":
-                    if (secondAction == "refresh")
-                        goto case "mr";
-                    if (secondAction == "enable")
-                        goto case "me";
-                    if (secondAction == "disable")
-                        goto case "md";
-                    break;
-                case "backup":
-                case "b":
-                    requestedAction = "b";
-                    break;
-                case "reset":
-                case "r":
-                    requestedAction = "r";
-                    break;
-                case "problemcheck":
-                case "pc":
-                    requestedAction = "pc";
-                    break;
-                case "version":
-                case "v":
-                    requestedAction = "v";
-                    break;
-                case "help":
-                case "h":
-                    requestedAction = "h";
-                    break;
-                default:
-                    main.PrintMessage($"Unknown action: {args[0]}");
-                    requestedAction = "h";
-                    break;
+                switch (args[0])
+                {
+                    case "mpi":
+                        requestedAction = "mpi";
+                        break;
+                    case "mpinfo":
+                        requestedAction = "mpinfo";
+                        break;
+                    case "modpack":
+                        if (secondAction == "import")
+                            goto case "mpi";
+                        if (secondAction == "info")
+                            goto case "mpinfo";
+                        break;
+                    case "mr":
+                        requestedAction = "mr";
+                        break;
+                    case "me":
+                        requestedAction = "me";
+                        break;
+                    case "md":
+                        requestedAction = "md";
+                        break;
+                    case "mods":
+                        if (secondAction == "refresh")
+                            goto case "mr";
+                        if (secondAction == "enable")
+                            goto case "me";
+                        if (secondAction == "disable")
+                            goto case "md";
+                        break;
+                    case "backup":
+                    case "b":
+                        requestedAction = "b";
+                        break;
+                    case "reset":
+                    case "r":
+                        requestedAction = "r";
+                        break;
+                    case "problemcheck":
+                    case "pc":
+                        requestedAction = "pc";
+                        break;
+                    case "version":
+                    case "v":
+                        requestedAction = "v";
+                        break;
+                    case "help":
+                    case "h":
+                        requestedAction = "h";
+                        break;
+                    default:
+                        main.PrintMessage($"Unknown action: {args[0]}");
+                        requestedAction = "h";
+                        break;
+                }
             }
         }
 

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -303,7 +303,9 @@ Available arguments:
   -b, --backupdirectory    Full path to directory with your index backups
   -t, --ttmp               Full path to .ttmp(2) file (modpack import/info only)
   -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
-  -npc, --noproblemcheck   Skip the problem check after importing a modpack";
+  -npc, --noproblemcheck   Skip the problem check after importing a modpack
+  -v, --version            Display current application and game version
+  -h, --help               Display this text";
             main.PrintMessage(helpText);
         }
     }

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -66,7 +66,7 @@ Available arguments:
                                 MainClass._indexDirectory = new DirectoryInfo(Path.Combine(nextArg, "game", "sqpack", "ffxiv"));
                                 if (!main.ValidGameDirectory())
                                 {
-                                    main.PrintMessage($"{nextArg} is not a valid game directory. Falling back to config file", 3);
+                                    main.PrintMessage($"Invalid game directory: {nextArg}\nFalling back to config file", 3);
                                     MainClass._gameDirectory = null;
                                     MainClass._indexDirectory = null;
                                 }
@@ -79,7 +79,7 @@ Available arguments:
                                 MainClass._configDirectory = new DirectoryInfo(nextArg);
                                 if (!main.ValidGameConfigDirectory())
                                 {
-                                    main.PrintMessage($"{nextArg} is not a valid game config directory. Falling back to config file", 3);
+                                    main.PrintMessage($"Invalid game config directory: {nextArg}\nFalling back to config file", 3);
                                     MainClass._configDirectory = null;
                                 }
                             }
@@ -91,7 +91,7 @@ Available arguments:
                                 MainClass._backupDirectory = new DirectoryInfo(nextArg);
                                 if (!main.ValidBackupDirectory())
                                 {
-                                    main.PrintMessage($"{nextArg} does not exist. Falling back to config file", 3);
+                                    main.PrintMessage($"Directory does not exist: {nextArg}\nFalling back to config file", 3);
                                     MainClass._backupDirectory = null;
                                 }
                             }

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -227,7 +227,7 @@ namespace FFXIV_Modding_Tool.Commandline
 
         public void ActionHandler()
         {
-            var modding = new Modding(MainClass._indexDirectory);
+            Modding modding;
             switch (requestedAction)
             {
                 case "h":
@@ -252,11 +252,13 @@ Number of mods: {modpackInfo["modAmount"]}");
                     main.SetModActiveStates();
                     break;
                 case "me":
+                    modding = new Modding(MainClass._indexDirectory);
                     main.PrintMessage("Enabling all mods...");
                     modding.ToggleAllMods(true);
                     main.PrintMessage("Successfully enabled all mods", 1);
                     break;
                 case "md":
+                    modding = new Modding(MainClass._indexDirectory);
                     main.PrintMessage("Disabling all mods...");
                     modding.ToggleAllMods(false);
                     main.PrintMessage("Successfully disabled all mods", 1);

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -47,6 +47,14 @@ namespace FFXIV_Modding_Tool.Commandline
                     string arg = cmdArg.Split('-').Last();
                     switch (arg)
                     {
+                        case "h":
+                        case "help":
+                            requestedAction = "h";
+                            continue;
+                        case "v":
+                        case "version":
+                            requestedAction = "v";
+                            continue;
                         case "g":
                         case "gamedirectory":
                             if (!nextArg.StartsWith("-"))

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -168,39 +168,21 @@ namespace FFXIV_Modding_Tool.Commandline
             List<string> requiresUpdatedBackups = new List<string> { "mpi", "mr", "me", "md", "r" };
             List<string> requiresValidIndexes = new List<string> { "mpi", "b" };
             List<string> requiresTTMPFile = new List<string> { "mpi", "mpinfo" };
+
             if (requiresGameDirectory.Contains(requestedAction))
             {
-                if (MainClass._indexDirectory == null)
-                {
-                    string configGameDirectory = config.ReadConfig("GameDirectory");
-                    MainClass._gameDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game"));
-                    MainClass._indexDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game", "sqpack", "ffxiv"));
-                }
-                if (MainClass._indexDirectory == null || !validation.ValidateDirectory(MainClass._indexDirectory, "GameDirectory"))
-                {
-                    main.PrintMessage("Invalid game directory", 2);
+                if (!CheckGameDirectory())
                     return false;
-                }
             }
             if (requiresBackupDirectory.Contains(requestedAction))
             {
-                if (MainClass._backupDirectory == null)
-                    MainClass._backupDirectory = new DirectoryInfo(config.ReadConfig("BackupDirectory"));
-                if (MainClass._backupDirectory == null || !validation.ValidateDirectory(MainClass._backupDirectory, "BackupDirectory"))
-                {
-                    main.PrintMessage("Invalid backup directory", 2);
+                if (!CheckBackupDirectory())
                     return false;
-                }
             }
             if (requiresConfigDirectory.Contains(requestedAction))
             {
-                if (MainClass._configDirectory == null)
-                    MainClass._configDirectory = new DirectoryInfo(config.ReadConfig("ConfigDirectory"));
-                if (MainClass._configDirectory == null || !validation.ValidateDirectory(MainClass._configDirectory, "ConfigDirectory"))
-                {
-                    main.PrintMessage("Invalid game config directory", 2);
+                if (!CheckConfigDirectory())
                     return false;
-                }
             }
             if (requiresUpdatedBackups.Contains(requestedAction))
             {
@@ -214,16 +196,63 @@ namespace FFXIV_Modding_Tool.Commandline
             }
             if (requiresTTMPFile.Contains(requestedAction))
             {
-                if (string.IsNullOrEmpty(ttmpPath))
-                {
-                    main.PrintMessage("Can't import without a modpack to import. Specify one with -t", 2);
+                if (!CheckTTMPFile())
                     return false;
-                }
-                if (!validation.ValidateTTMPFile(ttmpPath))
-                {
-                    main.PrintMessage("Invalid ttmp file", 2);
-                    return false;
-                }
+            }
+            return true;
+        }
+
+        bool CheckGameDirectory()
+        {
+            if (MainClass._indexDirectory == null)
+            {
+                string configGameDirectory = config.ReadConfig("GameDirectory");
+                MainClass._gameDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game"));
+                MainClass._indexDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game", "sqpack", "ffxiv"));
+            }
+            if (MainClass._indexDirectory == null || !validation.ValidateDirectory(MainClass._indexDirectory, "GameDirectory"))
+            {
+                main.PrintMessage("Invalid game directory", 2);
+                return false;
+            }
+            return true;
+        }
+
+        bool CheckBackupDirectory()
+        {
+            if (MainClass._backupDirectory == null)
+                MainClass._backupDirectory = new DirectoryInfo(config.ReadConfig("BackupDirectory"));
+            if (MainClass._backupDirectory == null || !validation.ValidateDirectory(MainClass._backupDirectory, "BackupDirectory"))
+            {
+                main.PrintMessage("Invalid backup directory", 2);
+                return false;
+            }
+            return true;
+        }
+
+        bool CheckConfigDirectory()
+        {
+            if (MainClass._configDirectory == null)
+                MainClass._configDirectory = new DirectoryInfo(config.ReadConfig("ConfigDirectory"));
+            if (MainClass._configDirectory == null || !validation.ValidateDirectory(MainClass._configDirectory, "ConfigDirectory"))
+            {
+                main.PrintMessage("Invalid game config directory", 2);
+                return false;
+            }
+            return true;
+        }
+
+        bool CheckTTMPFile()
+        {
+            if (string.IsNullOrEmpty(ttmpPath))
+            {
+                main.PrintMessage("Can't import without a modpack to import. Specify one with -t", 2);
+                return false;
+            }
+            if (!validation.ValidateTTMPFile(ttmpPath))
+            {
+                main.PrintMessage("Invalid ttmp file", 2);
+                return false;
             }
             return true;
         }

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
-using xivModdingFramework.General.Enums;
 using xivModdingFramework.Mods;
-using xivModdingFramework.Mods.DataContainers;
-using xivModdingFramework.Helpers;
 using System.Collections.Generic;
+using FFXIV_Modding_Tool.Configuration;
+using FFXIV_Modding_Tool.Validation;
 
 namespace FFXIV_Modding_Tool.Commandline
 {
@@ -14,38 +12,30 @@ namespace FFXIV_Modding_Tool.Commandline
     {
         public Arguments(){}
         MainClass main = new MainClass();
+        Config config = new Config();
+        Validators validation = new Validators();
         string ttmpPath = "";
         bool customImport = false;
         bool skipProblemCheck = false;
-        string helpText = $@"Usage: {Path.GetFileName(Environment.GetCommandLineArgs()[0])} [action] {"{arguments}"}
-
-Available actions:
-  modpack import, mpi      Import a modpack, requires a .ttmp(2) to be specified
-  modpack info, mpinfo     Show info about a modpack, requires a .ttmp(2) to be specified
-  mods enable, me          Enable all installed mods
-  mods disable, md         Disable all installed mods
-  mods refresh, mr         Enable/disable mods as specified in modlist.cfg
-  backup, b                Backup clean index files for use in resetting the game
-  reset, r                 Reset game to clean state
-  problemcheck, pc         Check if there are any problems with the game, mod or backup files
-  version, v               Display current application and game version
-  help, h                  Display this text
-
-Available arguments:
-  -g, --gamedirectory      Full path to game install, including 'FINAL FANTASY XIV - A Realm Reborn'
-  -c, --configdirectory    Full path to directory where FFXIV.cfg and character data is saved, including 'FINAL FANTASY XIV - A Realm Reborn'
-  -b, --backupdirectory    Full path to directory with your index backups
-  -t, --ttmp               Full path to .ttmp(2) file (modpack import/info only)
-  -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
-  -npc, --noproblemcheck   Skip the problem check after importing a modpack";
+        string requestedAction = "";
 
         public void ArgumentHandler(string[] args)
         {
+            if (!File.Exists(Config.configFile) || string.IsNullOrEmpty(File.ReadAllText(Config.configFile)))
+                config.CreateDefaultConfig();
             if (args.Length == 0)
             {
-                main.PrintMessage(helpText);
+                SendHelpText();
                 return;
             }
+            ReadArguments(args);
+            ReadAction(args);
+            if (ActionRequirementsChecker())
+                ActionHandler();
+        }
+
+        public void ReadArguments(string[] args)
+        { 
             foreach (string cmdArg in args)
             {
                 string nextArg = "";
@@ -63,37 +53,17 @@ Available arguments:
                             {
                                 MainClass._gameDirectory = new DirectoryInfo(Path.Combine(nextArg, "game"));
                                 MainClass._indexDirectory = new DirectoryInfo(Path.Combine(nextArg, "game", "sqpack", "ffxiv"));
-                                if (!main.ValidGameDirectory())
-                                {
-                                    main.PrintMessage($"Invalid game directory: {nextArg}\nFalling back to config file", 3);
-                                    MainClass._gameDirectory = null;
-                                    MainClass._indexDirectory = null;
-                                }
                             }
                             continue;
                         case "c":
                         case "configdirectory":
                             if (!nextArg.StartsWith("-"))
-                            {
                                 MainClass._configDirectory = new DirectoryInfo(nextArg);
-                                if (!main.ValidGameConfigDirectory())
-                                {
-                                    main.PrintMessage($"Invalid game config directory: {nextArg}\nFalling back to config file", 3);
-                                    MainClass._configDirectory = null;
-                                }
-                            }
                             continue;
                         case "b":
                         case "backupdirectory":
                             if (!nextArg.StartsWith("-"))
-                            {
                                 MainClass._backupDirectory = new DirectoryInfo(nextArg);
-                                if (!main.ValidBackupDirectory())
-                                {
-                                    main.PrintMessage($"Directory does not exist: {nextArg}\nFalling back to config file", 3);
-                                    MainClass._backupDirectory = null;
-                                }
-                            }
                             continue;
                         case "t":
                         case "ttmp":
@@ -116,7 +86,7 @@ Available arguments:
             }
         }
 
-        public void ActionHandler(string[] args)
+        public void ReadAction(string[] args)
         { 
             string secondAction = "";
             if (args.Count() > 1)
@@ -124,33 +94,10 @@ Available arguments:
             switch (args[0])
             {
                 case "mpi":
-                    if (string.IsNullOrEmpty(ttmpPath))
-                    {
-                        main.PrintMessage("Can't import without a modpack to import. Specify one with -t", 2);
-                        return;
-                    }
-                    if (BackupsMissingOrOutdated())
-                        return;
-                    if (PreviouslyModifiedGame())
-                        return;
-                    if (MainClass._gameDirectory != null)
-                        main.ImportModpackHandler(new DirectoryInfo(ttmpPath), customImport, skipProblemCheck);
-                    else
-                        main.PrintMessage("Importing requires having your game directory set either through the config file or with -g specified", 2);
+                    requestedAction = "mpi";
                     break;
                 case "mpinfo":
-                    if (string.IsNullOrEmpty(ttmpPath))
-                        main.PrintMessage("Can't show info without a modpack to read. Specify one with -t", 2);
-                    else
-                    {
-                        Dictionary<string, string> modpackInfo = main.GetModpackInfo(new DirectoryInfo(ttmpPath));
-                        main.PrintMessage($@"Name: {modpackInfo["name"]}
-Type: {modpackInfo["type"]}
-Author: {modpackInfo["author"]}
-Version: {modpackInfo["version"]}
-Description: {modpackInfo["description"]}
-Number of mods: {modpackInfo["modAmount"]}");
-                    }
+                    requestedAction = "mpinfo";
                     break;
                 case "modpack":
                     if (secondAction == "import")
@@ -159,32 +106,13 @@ Number of mods: {modpackInfo["modAmount"]}");
                         goto case "mpinfo";
                     break;
                 case "mr":
-                    if (MainClass._gameDirectory != null)
-                        main.SetModActiveStates();
-                    else
-                        main.PrintMessage("Enabling/disabling mods requires having your game directory set either through the config file or with -g specified", 2);
+                    requestedAction = "mr";
                     break;
                 case "me":
-                    if (MainClass._gameDirectory != null)
-                    {
-                        var modding = new Modding(MainClass._indexDirectory);
-                        main.PrintMessage("Enabling all mods...");
-                        modding.ToggleAllMods(true);
-                        main.PrintMessage("Successfully enabled all mods", 1);
-                    }
-                    else
-                        main.PrintMessage("Enabling mods requires having your game directory set either through the config file or with -g specified", 2);
+                    requestedAction = "me";
                     break;
                 case "md":
-                    if (MainClass._gameDirectory != null)
-                    {
-                        var modding = new Modding(MainClass._indexDirectory);
-                        main.PrintMessage("Disabling all mods...");
-                        modding.ToggleAllMods(false);
-                        main.PrintMessage("Successfully disabled all mods", 1);
-                    }
-                    else
-                        main.PrintMessage("Disabling mods requires having your game directory set either through the config file or with -g specified", 2);
+                    requestedAction = "md";
                     break;
                 case "mods":
                     if (secondAction == "refresh")
@@ -196,149 +124,174 @@ Number of mods: {modpackInfo["modAmount"]}");
                     break;
                 case "backup":
                 case "b":
-                    if (PreviouslyModifiedGame())
-                        return;
-                    if (MainClass._gameDirectory != null && MainClass._backupDirectory != null)
-                        main.BackupIndexes();
-                    else
-                        main.PrintMessage("Backing up index files requires having both your game and backup directories set through the config file or with -g and -b specified", 2);
+                    requestedAction = "b";
                     break;
                 case "reset":
                 case "r":
-                    if (MainClass._gameDirectory != null && MainClass._backupDirectory != null)
-                        main.ResetMods();
-                    else
-                        main.PrintMessage("Resetting game files requires having both your game and backup directories set through the config file or with -g and -b specified", 2);
+                    requestedAction = "r";
                     break;
                 case "problemcheck":
                 case "pc":
-                    if (PreviouslyModifiedGame())
-                        return;
-                    if (MainClass._gameDirectory != null && MainClass._backupDirectory != null && MainClass._configDirectory != null)
-                        main.ProblemChecker();
-                    else
-                        main.PrintMessage("Checking for problems requires having your game, backup and config directories set through the config file or with -g, -b and -c specified", 2);
+                    requestedAction = "pc";
                     break;
                 case "version":
                 case "v":
-                    main.CheckVersions();
+                    requestedAction = "v";
                     break;
                 case "help":
                 case "h":
-                    main.PrintMessage(helpText);
+                    requestedAction = "h";
                     break;
                 default:
                     main.PrintMessage($"Unknown action: {args[0]}");
-                    main.PrintMessage(helpText);
+                    requestedAction = "h";
                     break;
             }
         }
 
-        bool BackupsMissingOrOutdated()
+        public bool ActionRequirementsChecker()
         {
-            main.PrintMessage("Checking backups before proceeding...");
-            bool keepGoing = true;
-            bool problemFound = false;
-            if (MainClass._backupDirectory == null)
+            List<string> requiresGameDirectory = new List<string> { "mpi", "mr", "me", "md", "b", "r", "pc" };
+            List<string> requiresBackupDirectory = new List<string> { "mpi", "mr", "me", "md", "b", "r", "pc" };
+            List<string> requiresConfigDirectory = new List<string> { "mpi", "pc" };
+            List<string> requiresUpdatedBackups = new List<string> { "mpi", "mr", "me", "md", "r" };
+            List<string> requiresValidIndexes = new List<string> { "mpi", "b" };
+            List<string> requiresTTMPFile = new List<string> { "mpi", "mpinfo" };
+            if (requiresGameDirectory.Contains(requestedAction))
             {
-                main.PrintMessage($"No backup directory specified, can't check the status of backups.\nYou are strongly recommended to add a backup directory in {Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg")} and running the 'backup' command before proceeding", 2);
-                problemFound = true;
-            }
-            else if (MainClass._gameDirectory == null)
-            {
-                main.PrintMessage("No game directory specified, can't check if backups are up to date", 2);
-                problemFound = true;
-            }
-            else
-            {
-                var filesToCheck = new XivDataFile[] { XivDataFile._01_Bgcommon, XivDataFile._04_Chara, XivDataFile._06_Ui };
-                ProblemChecker problemChecker = new ProblemChecker(MainClass._indexDirectory);
-                foreach (var file in filesToCheck)
+                if (MainClass._indexDirectory == null)
                 {
-                    if (!File.Exists(Path.Combine(MainClass._backupDirectory.FullName, $"{file.GetDataFileName()}.win32.index")))
-                    {
-                        main.PrintMessage($"One or more index files could not be found in {MainClass._backupDirectory.FullName}. Creating new ones or downloading them from the TexTools discord is recommended", 2);
-                        problemFound = true;
-                        break;
-                    }
-                    var outdatedBackupsCheck = problemChecker.CheckForOutdatedBackups(file, MainClass._backupDirectory);
-                    outdatedBackupsCheck.Wait();
-                    if (!outdatedBackupsCheck.Result)
-                    {
-                        main.PrintMessage($"One or more index files are out of date in {MainClass._backupDirectory.FullName}. Recreating or downloading them from the TexTools discord is recommended", 2);
-                        problemFound = true;
-                        break;
-                    }
+                    string configGameDirectory = config.ReadConfig("GameDirectory");
+                    MainClass._gameDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game"));
+                    MainClass._indexDirectory = new DirectoryInfo(Path.Combine(configGameDirectory, "game", "sqpack", "ffxiv"));
+                }
+                if (MainClass._indexDirectory == null || !validation.ValidateDirectory(MainClass._indexDirectory, "GameDirectory"))
+                {
+                    main.PrintMessage("Invalid game directory", 2);
+                    return false;
                 }
             }
-            if (problemFound)
-                keepGoing = PromptContinuation();
-            else
-                main.PrintMessage("All backups present and up to date", 1);
-            return !keepGoing;
+            if (requiresBackupDirectory.Contains(requestedAction))
+            {
+                if (MainClass._backupDirectory == null)
+                    MainClass._backupDirectory = new DirectoryInfo(config.ReadConfig("BackupDirectory"));
+                if (MainClass._backupDirectory == null || !validation.ValidateDirectory(MainClass._backupDirectory, "BackupDirectory"))
+                {
+                    main.PrintMessage("Invalid backup directory", 2);
+                    return false;
+                }
+            }
+            if (requiresConfigDirectory.Contains(requestedAction))
+            {
+                if (MainClass._configDirectory == null)
+                    MainClass._configDirectory = new DirectoryInfo(config.ReadConfig("ConfigDirectory"));
+                if (MainClass._configDirectory == null || !validation.ValidateDirectory(MainClass._configDirectory, "ConfigDirectory"))
+                {
+                    main.PrintMessage("Invalid game config directory", 2);
+                    return false;
+                }
+            }
+            if (requiresUpdatedBackups.Contains(requestedAction))
+            {
+                if (!validation.ValidateBackups())
+                    return false;
+            }
+            if (requiresValidIndexes.Contains(requestedAction))
+            {
+                if (!validation.ValidateIndexFiles())
+                    return false;
+            }
+            if (requiresTTMPFile.Contains(requestedAction))
+            {
+                if (string.IsNullOrEmpty(ttmpPath))
+                {
+                    main.PrintMessage("Can't import without a modpack to import. Specify one with -t", 2);
+                    return false;
+                }
+                if (!validation.ValidateTTMPFile(ttmpPath))
+                {
+                    main.PrintMessage("Invalid ttmp file", 2);
+                    return false;
+                }
+            }
+            return true;
         }
 
-        bool PreviouslyModifiedGame()
+        public void ActionHandler()
         {
-            bool keepGoing = true;
-            if (MainClass._gameDirectory != null)
+            var modding = new Modding(MainClass._indexDirectory);
+            switch (requestedAction)
             {
-                string modlistPath = Path.Combine(MainClass._gameDirectory.FullName, "XivMods.json");
-                if (!File.Exists(modlistPath))
-                {
-                    ProblemChecker problemChecker = new ProblemChecker(MainClass._indexDirectory);
-                    var filesToCheck = new XivDataFile[] { XivDataFile._0A_Exd, XivDataFile._01_Bgcommon, XivDataFile._04_Chara, XivDataFile._06_Ui };
-                    bool modifiedIndex = false;
-                    foreach (var file in filesToCheck)
-                    {
-                        var datCountCheck = problemChecker.CheckIndexDatCounts(file);
-                        datCountCheck.Wait();
-                        if (datCountCheck.Result)
-                        {
-                            modifiedIndex = true;
-                            break;
-                        }
-                    }
-                    if (modifiedIndex)
-                    {
-                        main.PrintMessage("HERE BE DRAGONS\nPreviously modified game files found\nUse the originally used tool to start over, or reinstall the game before using this tool", 2);
-                        keepGoing = PromptContinuation();
-                    }
-                }
-                else
-                {
-                    var modData = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(modlistPath));
-                    bool unsupportedSource = false;
-                    foreach (Mod mod in modData.Mods)
-                    {
-                        if (mod.source != "FFXIV_Modding_Tool")
-                        {
-                            unsupportedSource = true;
-                            break;
-                        }
-                    }
-                    if (unsupportedSource)
-                    {
-                        main.PrintMessage("Found a mod applied by an unknown application, game stability cannot be guaranteed", 3);
-                        keepGoing = PromptContinuation();
-                    }
-                }
+                case "h":
+                    SendHelpText();
+                    break;
+                case "v":
+                    main.CheckVersions();
+                    break;
+                case "mpi":
+                    main.ImportModpackHandler(new DirectoryInfo(ttmpPath), customImport, skipProblemCheck);
+                    break;
+                case "mpinfo":
+                    Dictionary<string, string> modpackInfo = main.GetModpackInfo(new DirectoryInfo(ttmpPath));
+                    main.PrintMessage($@"Name: {modpackInfo["name"]}
+Type: {modpackInfo["type"]}
+Author: {modpackInfo["author"]}
+Version: {modpackInfo["version"]}
+Description: {modpackInfo["description"]}
+Number of mods: {modpackInfo["modAmount"]}");
+                    break;
+                case "mr":
+                    main.SetModActiveStates();
+                    break;
+                case "me":
+                    main.PrintMessage("Enabling all mods...");
+                    modding.ToggleAllMods(true);
+                    main.PrintMessage("Successfully enabled all mods", 1);
+                    break;
+                case "md":
+                    main.PrintMessage("Disabling all mods...");
+                    modding.ToggleAllMods(false);
+                    main.PrintMessage("Successfully disabled all mods", 1);
+                    break;
+                case "b":
+                    main.BackupIndexes();
+                    break;
+                case "r":
+                    main.ResetMods();
+                    break;
+                case "pc":
+                    main.ProblemChecker();
+                    break;
+                default:
+                    SendHelpText();
+                    break;
             }
-            return !keepGoing;
         }
 
-        bool PromptContinuation()
+        public void SendHelpText()
         {
-            main.PrintMessage("Continue anyway? y/N");
-            string answer = Console.ReadKey().KeyChar.ToString();
-            if (answer == "y")
-            {
-                Console.Write("\n");
-                return true;
-            }
-            if (answer != "\n")
-                Console.Write("\n");
-            return false;
+            string helpText = $@"Usage: {Path.GetFileName(Environment.GetCommandLineArgs()[0])} [action] {"{arguments}"}
+
+Available actions:
+  modpack import, mpi      Import a modpack, requires a .ttmp(2) to be specified
+  modpack info, mpinfo     Show info about a modpack, requires a .ttmp(2) to be specified
+  mods enable, me          Enable all installed mods
+  mods disable, md         Disable all installed mods
+  mods refresh, mr         Enable/disable mods as specified in modlist.cfg
+  backup, b                Backup clean index files for use in resetting the game
+  reset, r                 Reset game to clean state
+  problemcheck, pc         Check if there are any problems with the game, mod or backup files
+  version, v               Display current application and game version
+  help, h                  Display this text
+
+Available arguments:
+  -g, --gamedirectory      Full path to game install, including 'FINAL FANTASY XIV - A Realm Reborn'
+  -c, --configdirectory    Full path to directory where FFXIV.cfg and character data is saved, including 'FINAL FANTASY XIV - A Realm Reborn'
+  -b, --backupdirectory    Full path to directory with your index backups
+  -t, --ttmp               Full path to .ttmp(2) file (modpack import/info only)
+  -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
+  -npc, --noproblemcheck   Skip the problem check after importing a modpack";
+            main.PrintMessage(helpText);
         }
     }
 }

--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -14,10 +14,10 @@ namespace FFXIV_Modding_Tool.Commandline
     {
         public Arguments(){}
         MainClass main = new MainClass();
-
-        public void ArgumentHandler(string[] args)
-        {
-            string helpText = $@"Usage: {Path.GetFileName(Environment.GetCommandLineArgs()[0])} [action] {"{arguments}"}
+        string ttmpPath = "";
+        bool customImport = false;
+        bool skipProblemCheck = false;
+        string helpText = $@"Usage: {Path.GetFileName(Environment.GetCommandLineArgs()[0])} [action] {"{arguments}"}
 
 Available actions:
   modpack import, mpi      Import a modpack, requires a .ttmp(2) to be specified
@@ -38,9 +38,10 @@ Available arguments:
   -t, --ttmp               Full path to .ttmp(2) file (modpack import/info only)
   -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
   -npc, --noproblemcheck   Skip the problem check after importing a modpack";
-            string ttmpPath = "";
-            bool customImport = false;
-            bool skipProblemCheck = false;
+
+        public void ArgumentHandler(string[] args)
+        {
+
             if (args.Length == 0)
             {
                 main.PrintMessage(helpText);
@@ -94,7 +95,10 @@ Available arguments:
                     }
                 }
             }
+        }
 
+        public void ActionHandler(string[] args)
+        { 
             string secondAction = "";
             if (args.Count() > 1)
                 secondAction = args[1];

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -52,7 +52,7 @@ ConfigDirectory",
                     MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
                     if (!main.ValidGameDirectory())
                     {
-                        main.PrintMessage($"{gameDirectory} is not a valid game directory", 2);
+                        main.PrintMessage($"Invalid game directory: {gameDirectory}", 2);
                         return false;
                     }
                 }
@@ -66,7 +66,7 @@ ConfigDirectory",
                     MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
                     if (!main.ValidBackupDirectory())
                     {
-                        main.PrintMessage($"{backupDirectory} does not exist", 2);
+                        main.PrintMessage($"Directory does not exist: {backupDirectory}", 2);
                         return false;
                     }
                 }
@@ -80,7 +80,7 @@ ConfigDirectory",
                     MainClass._configDirectory = new DirectoryInfo(configDirectory);
                     if (!main.ValidGameConfigDirectory())
                     {
-                        main.PrintMessage($"{configDirectory} is not a valid game config directory", 2);
+                        main.PrintMessage($"Invalid game config directory: {configDirectory}", 2);
                         return false;
                     }
                 }

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -6,15 +6,12 @@ namespace FFXIV_Modding_Tool.Configuration
 {
     public class Config
     {
-        public DirectoryInfo _projectconfDirectory = MainClass._projectconfDirectory;
+        string configFile = Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg");
 
-        public bool ReadConfig()
+        public void CreateDefaultConfig()
         {
-            MainClass main = new MainClass();
-            if (!Directory.Exists(_projectconfDirectory.FullName))
-                Directory.CreateDirectory(_projectconfDirectory.FullName);
-            string configFile = Path.Combine(_projectconfDirectory.FullName, "config.cfg");
-            var configFileFromPath = new ConfigParser(configFile);
+            if (!Directory.Exists(MainClass._projectconfDirectory.FullName))
+                Directory.CreateDirectory(MainClass._projectconfDirectory.FullName);
             var configFileFromString = new ConfigParser(@"[Directories]
 # All paths can be written with or without escaping
 
@@ -39,8 +36,14 @@ ConfigDirectory",
                     MultiLineValues = MultiLineValues.Simple | MultiLineValues.AllowValuelessKeys | MultiLineValues.QuoteDelimitedValues,
                     Culture = new CultureInfo("en-US")
                 });
-            if (!File.Exists(configFile) || string.IsNullOrEmpty(File.ReadAllText(configFile)))
-                configFileFromString.Save(configFile);
+            configFileFromString.Save(configFile);
+        }
+
+        public bool ReadConfig()
+        {
+            MainClass main = new MainClass();
+            var configFileFromPath = new ConfigParser(configFile);
+
             string gameDirectory = configFileFromPath.GetValue("Directories", "GameDirectory");
             string backupDirectory = configFileFromPath.GetValue("Directories", "BackupDirectory");
             string configDirectory = configFileFromPath.GetValue("Directories", "ConfigDirectory");

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -19,13 +19,20 @@ namespace FFXIV_Modding_Tool.Configuration
 # All paths can be written with or without escaping
 
 # Full path to game install, including 'FINAL FANTASY XIV - A Realm Reborn'
+# Example locations:
+#   MacOS: /Users/<USER_NAME>/Library/Application Support/FINAL FANTASY XIV ONLINE/Bottles/published_Final_Fantasy/drive_c/Program Files (x86)/SquareEnix/FINAL FANTASY XIV - A Realm Reborn
+#   Linux: /path/to/WINEBOTTLE/drive_c/Program Files (x86)/SquareEnix/FINAL FANTASY XIV - A Realm Reborn
+#   Windows: C:\Program Files (x86)\SquareEnix\FINAL FANTASY XIV - A Realm Reborn
 GameDirectory
 
 # Full path to directory with your index backups, this can be any directory where you wish to store your backups
 BackupDirectory
 
 # Full path to directory where FFXIV.cfg and character data is saved, including 'FINAL FANTASY XIV - A Realm Reborn'
-# This is usually located in 'My Documents/My Games', in your wine prefix if not on Windows
+# Example locations:
+#   MacOS: /Users/<USER_NAME>/My Documents/My Games/FINAL FANTASY XIV - A Realm Reborn
+#   Linux: /path/to/WINEBOTTLE/drive_c/users/<USER_NAME>/My Documents/My Games/FINAL FANTASY XIV - A Realm Reborn
+#   Windows: C:\users\<USER_NAME>\My Documents\My Games\FINAL FANTASY XIV - A Realm Reborn
 ConfigDirectory",
                 new ConfigParserSettings
                 {

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -8,7 +8,7 @@ namespace FFXIV_Modding_Tool.Configuration
     {
         public DirectoryInfo _projectconfDirectory = MainClass._projectconfDirectory;
 
-        public void ReadConfig()
+        public bool ReadConfig()
         {
             MainClass main = new MainClass();
             if (!Directory.Exists(_projectconfDirectory.FullName))
@@ -48,17 +48,37 @@ ConfigDirectory",
             {
                 MainClass._gameDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game"));
                 MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
+                if (!MainClass._indexDirectory.Exists || MainClass._indexDirectory.GetFiles("*.index").Length == 0)
+                {
+                    main.PrintMessage($"{gameDirectory} is not a valid game directory", 2);
+                    return false;
+                }
             }
             else
                 main.PrintMessage("No game install directory saved", 3);
             if (!string.IsNullOrEmpty(backupDirectory))
+            {
                 MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
+                if (!MainClass._backupDirectory.Exists)
+                {
+                    main.PrintMessage($"{backupDirectory} does not exist", 2);
+                    return false;
+                }
+            }
             else
                 main.PrintMessage("No index backup directory saved", 3);
             if (!string.IsNullOrEmpty(configDirectory))
+            {
                 MainClass._configDirectory = new DirectoryInfo(configDirectory);
+                if (!MainClass._configDirectory.Exists || MainClass._configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
+                {
+                    main.PrintMessage($"{configDirectory} is not a valid game config directory", 2);
+                    return false;
+                }
+            }
             else
                 main.PrintMessage("No game config directory saved", 3);
+            return true;
         }
     }
 }

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -50,7 +50,7 @@ ConfigDirectory",
                 {
                     MainClass._gameDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game"));
                     MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
-                    if (!MainClass._indexDirectory.Exists || MainClass._indexDirectory.GetFiles("*.index").Length == 0)
+                    if (!main.ValidGameDirectory())
                     {
                         main.PrintMessage($"{gameDirectory} is not a valid game directory", 2);
                         return false;
@@ -64,7 +64,7 @@ ConfigDirectory",
                 if (MainClass._backupDirectory == null)
                 {
                     MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
-                    if (!MainClass._backupDirectory.Exists)
+                    if (!main.ValidBackupDirectory())
                     {
                         main.PrintMessage($"{backupDirectory} does not exist", 2);
                         return false;
@@ -78,7 +78,7 @@ ConfigDirectory",
                 if (MainClass._configDirectory == null)
                 {
                     MainClass._configDirectory = new DirectoryInfo(configDirectory);
-                    if (!MainClass._configDirectory.Exists || MainClass._configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
+                    if (!main.ValidGameConfigDirectory())
                     {
                         main.PrintMessage($"{configDirectory} is not a valid game config directory", 2);
                         return false;

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -46,34 +46,43 @@ ConfigDirectory",
             string configDirectory = configFileFromPath.GetValue("Directories", "ConfigDirectory");
             if (!string.IsNullOrEmpty(gameDirectory))
             {
-                MainClass._gameDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game"));
-                MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
-                if (!MainClass._indexDirectory.Exists || MainClass._indexDirectory.GetFiles("*.index").Length == 0)
+                if (MainClass._gameDirectory == null)
                 {
-                    main.PrintMessage($"{gameDirectory} is not a valid game directory", 2);
-                    return false;
+                    MainClass._gameDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game"));
+                    MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
+                    if (!MainClass._indexDirectory.Exists || MainClass._indexDirectory.GetFiles("*.index").Length == 0)
+                    {
+                        main.PrintMessage($"{gameDirectory} is not a valid game directory", 2);
+                        return false;
+                    }
                 }
             }
             else
                 main.PrintMessage("No game install directory saved", 3);
             if (!string.IsNullOrEmpty(backupDirectory))
             {
-                MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
-                if (!MainClass._backupDirectory.Exists)
+                if (MainClass._backupDirectory == null)
                 {
-                    main.PrintMessage($"{backupDirectory} does not exist", 2);
-                    return false;
+                    MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
+                    if (!MainClass._backupDirectory.Exists)
+                    {
+                        main.PrintMessage($"{backupDirectory} does not exist", 2);
+                        return false;
+                    }
                 }
             }
             else
                 main.PrintMessage("No index backup directory saved", 3);
             if (!string.IsNullOrEmpty(configDirectory))
             {
-                MainClass._configDirectory = new DirectoryInfo(configDirectory);
-                if (!MainClass._configDirectory.Exists || MainClass._configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
+                if (MainClass._configDirectory == null)
                 {
-                    main.PrintMessage($"{configDirectory} is not a valid game config directory", 2);
-                    return false;
+                    MainClass._configDirectory = new DirectoryInfo(configDirectory);
+                    if (!MainClass._configDirectory.Exists || MainClass._configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
+                    {
+                        main.PrintMessage($"{configDirectory} is not a valid game config directory", 2);
+                        return false;
+                    }
                 }
             }
             else

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -39,58 +39,18 @@ ConfigDirectory",
             configFileFromString.Save(configFile);
         }
 
-        public bool ReadConfig()
+        public string ReadConfig(string target)
         {
             MainClass main = new MainClass();
             var configFileFromPath = new ConfigParser(configFile);
-
-            string gameDirectory = configFileFromPath.GetValue("Directories", "GameDirectory");
-            string backupDirectory = configFileFromPath.GetValue("Directories", "BackupDirectory");
-            string configDirectory = configFileFromPath.GetValue("Directories", "ConfigDirectory");
-            if (!string.IsNullOrEmpty(gameDirectory))
-            {
-                if (MainClass._gameDirectory == null)
-                {
-                    MainClass._gameDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game"));
-                    MainClass._indexDirectory = new DirectoryInfo(Path.Combine(gameDirectory, "game", "sqpack", "ffxiv"));
-                    if (!main.ValidGameDirectory())
-                    {
-                        main.PrintMessage($"Invalid game directory: {gameDirectory}", 2);
-                        return false;
-                    }
-                }
-            }
+            string targetDirectory = configFileFromPath.GetValue("Directories", target);
+            if (!string.IsNullOrEmpty(targetDirectory))
+                return targetDirectory;
             else
-                main.PrintMessage("No game install directory saved", 3);
-            if (!string.IsNullOrEmpty(backupDirectory))
             {
-                if (MainClass._backupDirectory == null)
-                {
-                    MainClass._backupDirectory = new DirectoryInfo(backupDirectory);
-                    if (!main.ValidBackupDirectory())
-                    {
-                        main.PrintMessage($"Directory does not exist: {backupDirectory}", 2);
-                        return false;
-                    }
-                }
+                main.PrintMessage($"{target} is empty", 2);
+                return null;
             }
-            else
-                main.PrintMessage("No index backup directory saved", 3);
-            if (!string.IsNullOrEmpty(configDirectory))
-            {
-                if (MainClass._configDirectory == null)
-                {
-                    MainClass._configDirectory = new DirectoryInfo(configDirectory);
-                    if (!main.ValidGameConfigDirectory())
-                    {
-                        main.PrintMessage($"Invalid game config directory: {configDirectory}", 2);
-                        return false;
-                    }
-                }
-            }
-            else
-                main.PrintMessage("No game config directory saved", 3);
-            return true;
         }
     }
 }

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -7,6 +7,7 @@ namespace FFXIV_Modding_Tool.Configuration
     public class Config
     {
         public static string configFile = Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg");
+        MainClass main = new MainClass();
 
         public void CreateDefaultConfig()
         {
@@ -37,11 +38,11 @@ ConfigDirectory",
                     Culture = new CultureInfo("en-US")
                 });
             configFileFromString.Save(configFile);
+            main.PrintMessage($"Config file saved to {configFile}", 1);
         }
 
         public string ReadConfig(string target)
         {
-            MainClass main = new MainClass();
             var configFileFromPath = new ConfigParser(configFile);
             string targetDirectory = configFileFromPath.GetValue("Directories", target);
             if (!string.IsNullOrEmpty(targetDirectory))

--- a/FFXIV_Modding_Tool/Configuration.cs
+++ b/FFXIV_Modding_Tool/Configuration.cs
@@ -6,7 +6,7 @@ namespace FFXIV_Modding_Tool.Configuration
 {
     public class Config
     {
-        string configFile = Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg");
+        public static string configFile = Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg");
 
         public void CreateDefaultConfig()
         {

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="Arguments.cs" />
+    <Compile Include="Validation.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -1223,8 +1223,6 @@ namespace FFXIV_Modding_Tool
             Config config = new Config();
             Arguments arguments = new Arguments();
             arguments.ArgumentHandler(args);
-            if (config.ReadConfig())
-                arguments.ActionHandler(args);
         }
     }
 }

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -1222,8 +1222,9 @@ namespace FFXIV_Modding_Tool
             _projectconfDirectory = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyTitleAttribute>().Title));
             Config config = new Config();
             Arguments arguments = new Arguments();
+            arguments.ArgumentHandler(args);
             if (config.ReadConfig())
-                arguments.ArgumentHandler(args);
+                arguments.ActionHandler(args);
         }
     }
 }

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -130,6 +130,27 @@ namespace FFXIV_Modding_Tool
             Console.ForegroundColor = ConsoleColor.White;
         }
 
+        public bool ValidGameDirectory()
+        {
+            if (!_indexDirectory.Exists || _indexDirectory.GetFiles("*.index").Length == 0)
+                return false;
+            return true;
+        }
+
+        public bool ValidBackupDirectory()
+        {
+            if (!_backupDirectory.Exists)
+                return false;
+            return true;
+        }
+
+        public bool ValidGameConfigDirectory()
+        {
+            if (!_configDirectory.Exists || _configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
+                return false;
+            return true;
+        }
+
         public void CheckVersions()
         {
             string ffxivVersion = "Not detected";

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -130,27 +130,6 @@ namespace FFXIV_Modding_Tool
             Console.ForegroundColor = ConsoleColor.White;
         }
 
-        public bool ValidGameDirectory()
-        {
-            if (!_indexDirectory.Exists || _indexDirectory.GetFiles("*.index").Length == 0)
-                return false;
-            return true;
-        }
-
-        public bool ValidBackupDirectory()
-        {
-            if (!_backupDirectory.Exists)
-                return false;
-            return true;
-        }
-
-        public bool ValidGameConfigDirectory()
-        {
-            if (!_configDirectory.Exists || _configDirectory.GetFiles("FFXIV*.cfg").Length == 0)
-                return false;
-            return true;
-        }
-
         public void CheckVersions()
         {
             string ffxivVersion = "Not detected";

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -1222,8 +1222,8 @@ namespace FFXIV_Modding_Tool
             _projectconfDirectory = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyTitleAttribute>().Title));
             Config config = new Config();
             Arguments arguments = new Arguments();
-            config.ReadConfig();
-            arguments.ArgumentHandler(args);
+            if (config.ReadConfig())
+                arguments.ArgumentHandler(args);
         }
     }
 }

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -3,9 +3,9 @@ using System.IO;
 
 namespace FFXIV_Modding_Tool.Validation
 {
-    public class Validation
+    public class Validators
     {
-        public Validation()
+        public Validators()
         {
         }
 

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.IO;
+using Newtonsoft.Json;
+using xivModdingFramework.General.Enums;
+using xivModdingFramework.Helpers;
+using xivModdingFramework.Mods.DataContainers;
 
 namespace FFXIV_Modding_Tool.Validation
 {
     public class Validators
     {
-        public Validators()
-        {
-        }
+        public Validators(){}
+        MainClass main = new MainClass();
 
         public bool ValidateDirectory(DirectoryInfo directory, string directoryType)
         {
@@ -31,6 +34,113 @@ namespace FFXIV_Modding_Tool.Validation
                         return false;
                 }
             }
+        }
+
+        public bool ValidateBackups()
+        {
+            main.PrintMessage("Checking backups before proceeding...");
+            bool keepGoing = true;
+            bool problemFound = false;
+            if (MainClass._backupDirectory == null)
+            {
+                main.PrintMessage($"No backup directory specified, can't check the status of backups.\nYou are strongly recommended to add a backup directory in {Path.Combine(MainClass._projectconfDirectory.FullName, "config.cfg")} and running the 'backup' command before proceeding", 2);
+                problemFound = true;
+            }
+            else if (MainClass._gameDirectory == null)
+            {
+                main.PrintMessage("No game directory specified, can't check if backups are up to date", 2);
+                problemFound = true;
+            }
+            else
+            {
+                var filesToCheck = new XivDataFile[] { XivDataFile._01_Bgcommon, XivDataFile._04_Chara, XivDataFile._06_Ui };
+                ProblemChecker problemChecker = new ProblemChecker(MainClass._indexDirectory);
+                foreach (var file in filesToCheck)
+                {
+                    if (!File.Exists(Path.Combine(MainClass._backupDirectory.FullName, $"{file.GetDataFileName()}.win32.index")))
+                    {
+                        main.PrintMessage($"One or more index files could not be found in {MainClass._backupDirectory.FullName}. Creating new ones or downloading them from the TexTools discord is recommended", 2);
+                        problemFound = true;
+                        break;
+                    }
+                    var outdatedBackupsCheck = problemChecker.CheckForOutdatedBackups(file, MainClass._backupDirectory);
+                    outdatedBackupsCheck.Wait();
+                    if (!outdatedBackupsCheck.Result)
+                    {
+                        main.PrintMessage($"One or more index files are out of date in {MainClass._backupDirectory.FullName}. Recreating or downloading them from the TexTools discord is recommended", 2);
+                        problemFound = true;
+                        break;
+                    }
+                }
+            }
+            if (problemFound)
+                keepGoing = PromptContinuation();
+            else
+                main.PrintMessage("All backups present and up to date", 1);
+            return !keepGoing;
+        }
+
+        public bool ValidateIndexFiles()
+        {
+            bool keepGoing = true;
+            if (MainClass._gameDirectory != null)
+            {
+                string modlistPath = Path.Combine(MainClass._gameDirectory.FullName, "XivMods.json");
+                if (!File.Exists(modlistPath))
+                {
+                    ProblemChecker problemChecker = new ProblemChecker(MainClass._indexDirectory);
+                    var filesToCheck = new XivDataFile[] { XivDataFile._0A_Exd, XivDataFile._01_Bgcommon, XivDataFile._04_Chara, XivDataFile._06_Ui };
+                    bool modifiedIndex = false;
+                    foreach (var file in filesToCheck)
+                    {
+                        var datCountCheck = problemChecker.CheckIndexDatCounts(file);
+                        datCountCheck.Wait();
+                        if (datCountCheck.Result)
+                        {
+                            modifiedIndex = true;
+                            break;
+                        }
+                    }
+                    if (modifiedIndex)
+                    {
+                        main.PrintMessage("HERE BE DRAGONS\nPreviously modified game files found\nUse the originally used tool to start over, or reinstall the game before using this tool", 2);
+                        keepGoing = PromptContinuation();
+                    }
+                }
+                else
+                {
+                    var modData = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(modlistPath));
+                    bool unsupportedSource = false;
+                    foreach (Mod mod in modData.Mods)
+                    {
+                        if (mod.source != "FFXIV_Modding_Tool")
+                        {
+                            unsupportedSource = true;
+                            break;
+                        }
+                    }
+                    if (unsupportedSource)
+                    {
+                        main.PrintMessage("Found a mod applied by an unknown application, game stability cannot be guaranteed", 3);
+                        keepGoing = PromptContinuation();
+                    }
+                }
+            }
+            return !keepGoing;
+        }
+
+        bool PromptContinuation()
+        {
+            main.PrintMessage("Continue anyway? y/N");
+            string answer = Console.ReadKey().KeyChar.ToString();
+            if (answer == "y")
+            {
+                Console.Write("\n");
+                return true;
+            }
+            if (answer != "\n")
+                Console.Write("\n");
+            return false;
         }
     }
 }

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -9,25 +9,28 @@ namespace FFXIV_Modding_Tool.Validation
         {
         }
 
-        public bool ValidGameDirectory(DirectoryInfo directory)
-        {
-            if (!directory.Exists || directory.GetFiles("*.index").Length == 0)
-                return false;
-            return true;
-        }
-
-        public bool ValidBackupDirectory(DirectoryInfo directory)
+        public bool ValidateDirectory(DirectoryInfo directory, string directoryType)
         {
             if (!directory.Exists)
                 return false;
-            return true;
-        }
-
-        public bool ValidGameConfigDirectory(DirectoryInfo directory)
-        {
-            if (!directory.Exists || directory.GetFiles("FFXIV*.cfg").Length == 0)
-                return false;
-            return true;
+            else
+            {
+                switch (directoryType)
+                {
+                    case "BackupDirectory":
+                        return true;
+                    case "GameDirectory":
+                        if (directory.GetFiles("*.index").Length == 0)
+                            return false;
+                        return true;
+                    case "ConfigDirectory":
+                        if (directory.GetFiles("FFXIV*.cfg").Length == 0)
+                            return false;
+                        return true;
+                    default:
+                        return false;
+                }
+            }
         }
     }
 }

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+
+namespace FFXIV_Modding_Tool
+{
+    public class Validation
+    {
+        public Validation()
+        {
+        }
+
+        public bool ValidGameDirectory(DirectoryInfo directory)
+        {
+            if (!directory.Exists || directory.GetFiles("*.index").Length == 0)
+                return false;
+            return true;
+        }
+
+        public bool ValidBackupDirectory(DirectoryInfo directory)
+        {
+            if (!directory.Exists)
+                return false;
+            return true;
+        }
+
+        public bool ValidGameConfigDirectory(DirectoryInfo directory)
+        {
+            if (!directory.Exists || directory.GetFiles("FFXIV*.cfg").Length == 0)
+                return false;
+            return true;
+        }
+    }
+}

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 
-namespace FFXIV_Modding_Tool
+namespace FFXIV_Modding_Tool.Validation
 {
     public class Validation
     {

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -84,7 +84,7 @@ namespace FFXIV_Modding_Tool.Validation
                 keepGoing = PromptContinuation();
             else
                 main.PrintMessage("All backups present and up to date", 1);
-            return !keepGoing;
+            return keepGoing;
         }
 
         public bool ValidateIndexFiles()
@@ -133,7 +133,7 @@ namespace FFXIV_Modding_Tool.Validation
                     }
                 }
             }
-            return !keepGoing;
+            return keepGoing;
         }
 
         bool PromptContinuation()

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -36,6 +36,13 @@ namespace FFXIV_Modding_Tool.Validation
             }
         }
 
+        public bool ValidateTTMPFile(string ttmpPath)
+        {
+            if (File.Exists(ttmpPath) && (ttmpPath.EndsWith(".ttmp") || ttmpPath.EndsWith(".ttmp2")))
+                return true;
+            return false;
+        }
+
         public bool ValidateBackups()
         {
             main.PrintMessage("Checking backups before proceeding...");


### PR DESCRIPTION
- [x] Unify checks between Config and Arguments while ensuring that arguments take priority.
- [x] Add example paths to config file
- [x] Ensure checks catch common errors (such as incorrect directory)
- [x] Ensure that help, version and mpinfo works without valid config/arguments.

Addresses https://github.com/fosspill/FFXIV_Modding_Tool/issues/82