### PR TITLE
Version bump for 0.7 release

### DIFF
--- a/FFXIV_Modding_Tool/Properties/AssemblyInfo.cs
+++ b/FFXIV_Modding_Tool/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.6.2.*")]
+[assembly: AssemblyVersion("0.7.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
In preparation of the 0.7 release the tool's version needs to be set to the new version so it will report the correct version to the user.