### PR TITLE
Wait for each mod toggle to be done

### DIFF
--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -1218,7 +1218,8 @@ namespace FFXIV_Modding_Tool
                 PrintMessage("Toggling mods...");
                 foreach (ModActiveStatus modState in modActiveStates)
                 {
-                    modding.ToggleModStatus(modState.file, modState.enabled);
+                    var toggle = modding.ToggleModStatus(modState.file, modState.enabled);
+                    toggle.Wait();
                     if (modState.enabled)
                         enabled++;
                     else


### PR DESCRIPTION
The framework has made the ToggleModStatus an asynchronous task, and so this function now needs to be waited for. This fixes #170 