### PR TITLE
0.9.3 hotfixes

### DIFF
--- a/FFXIV_Modding_Tool/Arguments.cs
+++ b/FFXIV_Modding_Tool/Arguments.cs
@@ -57,7 +57,7 @@ Author: {modpackInfo["author"]}
 Version: {modpackInfo["version"]}
 Description: {modpackInfo["description"]}
 Number of mods: {modpackInfo["modAmount"]}"); })},
-                {new List<string>{"mr", "mods reset"}, new Action(() => { main.SetModActiveStates(); })},
+                {new List<string>{"mr", "mods refresh"}, new Action(() => { main.SetModActiveStates(); })},
                 {new List<string>{"me", "mods enable"}, new Action(() => { main.ToggleModStates(true); })},
                 {new List<string>{"md", "mods disable"}, new Action(() => { main.ToggleModStates(false); })},
                 {new List<string>{"b", "backup"}, new Action(() => { main.BackupIndexes(); })},

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -25,5 +25,8 @@
   <Target Name="CopyFiles" AfterTargets="AfterBuild">
     <Copy SourceFiles="@(MyResourceFiles)" DestinationFolder="$(OutDir)\Resources\SQL" />
   </Target>
+  <Target Name="CopyFiles" AfterTargets="Publish">
+    <Copy SourceFiles="@(MyResourceFiles)" DestinationFolder="$(PublishDir)\Resources\SQL" />
+  </Target>
 
 </Project>

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>ffmt</AssemblyName>
-    <AssemblyVersion>0.9.3</AssemblyVersion>
+    <AssemblyVersion>0.9.3.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ICSharpCode.SharpZipLib.dll" Version="0.85.4.369" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -31,6 +31,7 @@ using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Textures.Enums;
 using FFXIV_Modding_Tool.Configuration;
 using FFXIV_Modding_Tool.Commandline;
+using FFXIV_Modding_Tool.Validation;
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
 
@@ -341,6 +342,7 @@ namespace FFXIV_Modding_Tool
 
         List<ModsJson> WizardDataHandler(ModPackJson ttmpData)
         {
+            Validators validation = new Validators();
             List<ModsJson> modpackData = new List<ModsJson>();
             PrintMessage($"\nName: {ttmpData.Name}\nVersion: {ttmpData.Version}\nAuthor: {ttmpData.Author}\n{ttmpData.Description}\n");
             foreach (var page in ttmpData.ModPackPages)
@@ -372,9 +374,7 @@ namespace FFXIV_Modding_Tool
                                 pickedChoices.Add($"{index} - {option.OptionList[index].Name}");
                             if (!pickedChoices.Any())
                                 pickedChoices.Add("nothing");
-                            Console.Write($"\nYou picked:\n{string.Join("\n", pickedChoices)}\nIs this correct? Y/n ");
-                            var answer = Console.ReadKey();
-                            if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
+                            if (validation.PromptContinuation($"\nYou picked:\n{string.Join("\n", pickedChoices)}\nIs this correct?", true))
                             {
                                 foreach (int index in wantedIndexes)
                                     modpackData.AddRange(option.OptionList[index].ModsJsons);
@@ -385,9 +385,7 @@ namespace FFXIV_Modding_Tool
                         {
                             Console.Write("Choose one (eg: 0 1 2 3): ");
                             int wantedIndex = WizardUserInputValidation(Console.ReadLine(), maxChoices, false)[0];
-                            Console.Write($"\nYou picked:\n{wantedIndex} - {option.OptionList[wantedIndex].Name}\nIs this correct? Y/n ");
-                            var answer = Console.ReadKey();
-                            if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
+                            if (validation.PromptContinuation($"\nYou picked:\n{wantedIndex} - {option.OptionList[wantedIndex].Name}\nIs this correct?", true))
                             {
                                 modpackData.AddRange(option.OptionList[wantedIndex].ModsJsons);
                                 userDone = true;
@@ -402,6 +400,7 @@ namespace FFXIV_Modding_Tool
 
         List<ModsJson> SimpleDataHandler(List<ModsJson> ttmpJson)
         {
+            Validators validation = new Validators();
             List<ModsJson> desiredMods = new List<ModsJson>();
             for (int i = 0; i < ttmpJson.Count; i = i + 50)
             {
@@ -423,9 +422,7 @@ namespace FFXIV_Modding_Tool
                         pickedMods.Add(mods[index]);
                     if (!pickedMods.Any())
                         pickedMods.Add("nothing");
-                    Console.Write($"\nYou picked:\n{string.Join("\n", pickedMods)}\nIs this correct? Y/n ");
-                    var answer = Console.ReadKey();
-                    if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
+                    if (validation.PromptContinuation($"\nYou picked:\n{string.Join("\n", pickedMods)}\nIs this correct?", true))
                     {
                         foreach (int index in wantedMods)
                             desiredMods.Add(items[index]);

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -253,14 +253,21 @@ namespace FFXIV_Modding_Tool
 
         List<ModsJson> TTMP2DataList(List<ModsJson> ttmpJson, ModPackJson ttmpData, bool useWizard, bool importAll)
         {
+            List<ModsJson> ttmpDataList = new List<ModsJson>();
             if (!useWizard && !importAll)
                 useWizard = PromptWizardUsage(ttmpJson.Count);
             if (useWizard)
             {
                 PrintMessage($"\nName: {ttmpData.Name}\nVersion: {ttmpData.Version}\nAuthor: {ttmpData.Author}\n");
-                return SimpleDataHandler(ttmpJson);
+                ttmpJson = SimpleDataHandler(ttmpJson);
             }
-            return ttmpJson;
+            foreach (ModsJson mod in ttmpJson)
+            {
+                if (mod.ModPackEntry == null)
+                    mod.ModPackEntry = new ModPack { name = ttmpData.Name, author = ttmpData.Author, version = ttmpData.Version, url = ttmpData.Url };
+                ttmpDataList.Add(mod);
+            }
+            return ttmpDataList;
         }
 
         List<ModsJson> TTMPDataList(DirectoryInfo ttmpPath, bool useWizard, bool importAll)

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,7 +33,6 @@ using xivModdingFramework.Textures.Enums;
 using FFXIV_Modding_Tool.Configuration;
 using FFXIV_Modding_Tool.Commandline;
 using FFXIV_Modding_Tool.Validation;
-using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
 
 namespace FFXIV_Modding_Tool
@@ -275,7 +275,7 @@ namespace FFXIV_Modding_Tool
             List<ModsJson> ttmpJson = new List<ModsJson>();
             var originalModPackData = GetOldModpackJson(ttmpPath);
             string ttmpName = Path.GetFileNameWithoutExtension(ttmpPath.FullName);
-
+            
             foreach (var modsJson in originalModPackData)
             {
                 ttmpJson.Add(new ModsJson
@@ -304,10 +304,10 @@ namespace FFXIV_Modding_Tool
         {
             List<OriginalModPackJson> originalModPackData = new List<OriginalModPackJson>();
             var fs = new FileStream(ttmpPath.FullName, FileMode.Open, FileAccess.Read);
-            ZipFile archive = new ZipFile(fs);
-            ZipEntry mplFile = archive.GetEntry("TTMPL.mpl");
+            ZipArchive archive = new ZipArchive(fs);
+            ZipArchiveEntry mplFile = archive.GetEntry("TTMPL.mpl");
             {
-                using (var streamReader = new StreamReader(archive.GetInputStream(mplFile)))
+                using (var streamReader = new StreamReader(mplFile.Open()))
                 {
                     string line;
                     while ((line = streamReader.ReadLine()) != null)

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -373,8 +373,8 @@ namespace FFXIV_Modding_Tool
                             if (!pickedChoices.Any())
                                 pickedChoices.Add("nothing");
                             Console.Write($"\nYou picked:\n{string.Join("\n", pickedChoices)}\nIs this correct? Y/n ");
-                            string answer = Console.ReadKey().KeyChar.ToString();
-                            if (answer == "y" || answer == "\n")
+                            var answer = Console.ReadKey();
+                            if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
                             {
                                 foreach (int index in wantedIndexes)
                                     modpackData.AddRange(option.OptionList[index].ModsJsons);
@@ -386,8 +386,8 @@ namespace FFXIV_Modding_Tool
                             Console.Write("Choose one (eg: 0 1 2 3): ");
                             int wantedIndex = WizardUserInputValidation(Console.ReadLine(), maxChoices, false)[0];
                             Console.Write($"\nYou picked:\n{wantedIndex} - {option.OptionList[wantedIndex].Name}\nIs this correct? Y/n ");
-                            string answer = Console.ReadKey().KeyChar.ToString();
-                            if (answer == "y" || answer == "\n")
+                            var answer = Console.ReadKey();
+                            if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
                             {
                                 modpackData.AddRange(option.OptionList[wantedIndex].ModsJsons);
                                 userDone = true;
@@ -424,8 +424,8 @@ namespace FFXIV_Modding_Tool
                     if (!pickedMods.Any())
                         pickedMods.Add("nothing");
                     Console.Write($"\nYou picked:\n{string.Join("\n", pickedMods)}\nIs this correct? Y/n ");
-                    string answer = Console.ReadKey().KeyChar.ToString();
-                    if (answer == "y" || answer == "\n")
+                    var answer = Console.ReadKey();
+                    if (answer.KeyChar.ToString() == "y" || answer.Key == ConsoleKey.Enter)
                     {
                         foreach (int index in wantedMods)
                             desiredMods.Add(items[index]);


### PR DESCRIPTION
  - `mods refresh` has now been spelled correctly
  - Y/n prompts will accept Return as choosing the default value
  - SharpZipLib was replaced with System.IO.Compression, as SharpZipLib is no longer compatible and caused .ttmp files to not import correctly
  - .ttmp2 files are now checked for missing information so they won't silently fail to import