### PR TITLE
Framework v2.3.1.8

### DIFF
--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>ffmt</AssemblyName>
-    <AssemblyVersion>0.9.4.1</AssemblyVersion>
+    <AssemblyVersion>0.9.5</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation with examples: https://ffmt.pwd.cat/docs/ 👈
 
 **This project is NOT affiliated with FFXIV_TexTools_UI**
 
-Depends on the latest version (2.3.1.4) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
+Depends on the latest version (2.3.1.8) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
 
 # Features!
 List is sorted by priority


### PR DESCRIPTION
This update brings the framework in line with the latest release version, and contains the following changes:

- Fixed importing mods in specific bad modlist/index states causing a semaphore error
- Added proper equipment decal mod support
- Added support for all DDS types
- Fixed ex bones support
- Fixed hair mod support