### PR TITLE
Small fixes

### DIFF
--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -211,13 +211,13 @@ Number of mods: {modpackInfo["modAmount"]}
                 ModPackJson ttmpData = null;
                 string ttmpName = null;
                 List<ModsJson> ttmpDataList = new List<ModsJson>();
+                PrintMessage($"Extracting data from {ttmpPath.Name}...");
                 if (ttmpPath.Extension == ".ttmp2")
                 {
                     var _ttmpData = ttmp.GetModPackJsonData(ttmpPath);
                     _ttmpData.Wait();
                     ttmpData = _ttmpData.Result.ModPackJson;
                 }
-                PrintMessage($"Extracting data from {ttmpPath.Name}...");
                 if (ttmpData != null)
                 {
                     ttmpName = ttmpData.Name;

--- a/FFXIV_Modding_Tool/Validation.cs
+++ b/FFXIV_Modding_Tool/Validation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -127,11 +127,12 @@ namespace FFXIV_Modding_Tool.Validation
                     bool unsupportedSource = false;
                     string unknownSource = "";
                     
-                    //List of acceptable mod sources
-                    //FFXIV_Modding_Tool is used by this tool
-                    //FilesAddedByTexTools is hardcoded in the framework and is used in certain situations
-                    //BLANK seems to be caused by a framework bug as well, so we allow it
-                    List<string> acceptedSourcesList = new List<string>{ "FFXIV_Modding_Tool", "FilesAddedByTexTools", "" };  
+                    /* List of acceptable mod sources
+                    FFXIV_Modding_Tool is used by this tool
+                    FilesAddedByTexTools is hardcoded in the framework and is used in certain situations
+                    _INTERNAL_ is hardcoded in the framework and used for metadata mods
+                    BLANK seems to be caused by a framework bug as well, so we allow it */
+                    List<string> acceptedSourcesList = new List<string>{ "FFXIV_Modding_Tool", "FilesAddedByTexTools", "", "_INTERNAL_" };  
                     foreach (Mod mod in modData.Mods)
                     {
                         if (!acceptedSourcesList.Contains(mod.source))


### PR DESCRIPTION
Moves the "Extracting data from modpack.ttmp" to an earlier point in the import process, where it should have been from the start.
Also adds the new hardcoded _INTERNAL_ modpack source for metadata mods.