### PR TITLE
Framework v2.3.4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation with examples: https://ffmt.pwd.cat/ 👈
 
 **This project is NOT affiliated with FFXIV_TexTools_UI**
 
-Depends on the latest stable version (2.3.4.16) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
+Depends on the latest stable version (2.3.4.18) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
 
 # Features!
 List is sorted by priority


### PR DESCRIPTION
This update brings the framework in line with the latest stable version, and contains the following changes:
- Updated base item sets file
- Fixed equipment decals under 100 not being accessible
- Fixed Chinese client issues with FFXIV patch 5.31