### PR TITLE
Switch to new type getting method

### DIFF
--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -772,7 +772,6 @@ Number of mods: {modpackInfo["modAmount"]}
                 return XivTexType.UI;
             else
                 return XivTexType.Other;
-
         }
 
         static readonly Dictionary<string, string> FaceTypes = new Dictionary<string, string>


### PR DESCRIPTION
Due to a change in how TTMP files are set up some mods failed to import with the error `The given key 'mdl' was not present in the dictionary.` By changing how we get the mod type this is no longer an issue.