### PR TITLE
Reset console color after printing error

### DIFF
--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -89,6 +89,7 @@ namespace FFXIV_Modding_Tool
                     Console.Write("ERROR: ");
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.WriteLine(message);
+                    Console.ResetColor();
                     Environment.Exit(1);
                     break;
                 case 3:


### PR DESCRIPTION
Depending on your shell or terminal settings, the console color could stay red when an error is printed and ffmt quits. This change resets the console color to your default before the program is quit to ensure this won't happen to anybody.