### PR TITLE
Framework Update to 2.3.6.1

### DIFF
--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.114.3" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="xivModdingFramework">

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.114" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.114.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="xivModdingFramework">

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.114" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="xivModdingFramework">

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.114.2" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.114.3" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="xivModdingFramework">

--- a/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
+++ b/FFXIV_Modding_Tool/FFXIV_Modding_Tool.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
   </ItemGroup>
   <ItemGroup>

--- a/FFXIV_Modding_Tool/Program.cs
+++ b/FFXIV_Modding_Tool/Program.cs
@@ -1209,6 +1209,7 @@ Number of mods: {modpackInfo["modAmount"]}
                 Validators validation = new Validators();
                 if (validation.PromptContinuation("Would you like to defragment your DAT files in an attempt to reclaim some space?", true))
                 {
+                    PrintMessage("Defragmenting...");
                     try
                     {
                         long savedBytes = 0;
@@ -1218,7 +1219,7 @@ Number of mods: {modpackInfo["modAmount"]}
                         defragmentation.Wait();
                         savedBytes = defragmentation.Result;
                         var savedSpace = FormatBytes(savedBytes);
-                        PrintMessage($"DAT file defragmentation completed successfully. {savedSpace} of unused space has been recovered.", 1);
+                        PrintMessage($"\nDAT file defragmentation completed successfully. {savedSpace} of unused space has been recovered.", 1);
                     }
                     catch (Exception ex)
                     {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation with examples: https://ffmt.pwd.cat/ 👈
 
 **This project is NOT affiliated with FFXIV_TexTools_UI**
 
-Depends on the latest stable version (2.3.5.10) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
+Depends on the latest stable version (2.3.6.1) of *[xivModdingFramework](https://github.com/TexTools/xivModdingFramework)*
 
 # Features!
 List is sorted by priority


### PR DESCRIPTION
Bumps System.Data.SQLite from 1.0.113.7 to 1.0.114.4.
Bumps SixLabors.ImageSharp from 1.0.0-beta0007 to 1.0.3.
Updates the framework to the latest stable 2.3.6.1 version.
Adds the option to defragment DAT files to the problem checker.